### PR TITLE
Quantize tflite model

### DIFF
--- a/convert_tensorflow.py
+++ b/convert_tensorflow.py
@@ -11,6 +11,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument('--net_type', default="RFB", type=str,
                     help='The network architecture ,optional: RFB (higher precision) or slim (faster)')
 parser.add_argument('--pytorch_model', default=None, type=str)
+parser.add_argument('--postprocess', action="store_true")
 args = parser.parse_args()
 
 
@@ -22,11 +23,11 @@ def main():
     if args.net_type == 'slim':
         torch_path = args.pytorch_model or "pytorch_pretrained/version-slim-320.pth"
         mapping_table = "mapping_tables/slim_320.json"
-        model = create_slim_net(input_shape, base_channel, num_classes, post_processing=False)
+        model = create_slim_net(input_shape, base_channel, num_classes, post_processing=args.postprocess)
     elif args.net_type == 'RFB':
         torch_path = args.pytorch_model or "pytorch_pretrained/version-RFB-320.pth"
         mapping_table = "mapping_tables/rfb_320.json"
-        model = create_rfb_net(input_shape, base_channel, num_classes)
+        model = create_rfb_net(input_shape, base_channel, num_classes, post_processing=args.postprocess)
     else:
         print("The net type is wrong!")
         sys.exit(1)

--- a/convert_tensorflow.py
+++ b/convert_tensorflow.py
@@ -10,6 +10,7 @@ parser = argparse.ArgumentParser(
 
 parser.add_argument('--net_type', default="RFB", type=str,
                     help='The network architecture ,optional: RFB (higher precision) or slim (faster)')
+parser.add_argument('--pytorch_model', default=None, type=str)
 args = parser.parse_args()
 
 
@@ -19,11 +20,11 @@ def main():
     num_classes = 2
 
     if args.net_type == 'slim':
-        torch_path = "pytorch_pretrained/version-slim-320.pth"
+        torch_path = args.pytorch_model or "pytorch_pretrained/version-slim-320.pth"
         mapping_table = "mapping_tables/slim_320.json"
-        model = create_slim_net(input_shape, base_channel, num_classes)
+        model = create_slim_net(input_shape, base_channel, num_classes, post_processing=False)
     elif args.net_type == 'RFB':
-        torch_path = "pytorch_pretrained/version-RFB-320.pth"
+        torch_path = args.pytorch_model or "pytorch_pretrained/version-RFB-320.pth"
         mapping_table = "mapping_tables/rfb_320.json"
         model = create_rfb_net(input_shape, base_channel, num_classes)
     else:

--- a/export_to_tflite.py
+++ b/export_to_tflite.py
@@ -50,8 +50,6 @@ def representative_dataset_generator():
         img = cv2.imread(str(p))
         i += 1
         yield [preprocess_image(img)]
-    
-
 
 
 def main():

--- a/export_to_tflite.py
+++ b/export_to_tflite.py
@@ -23,6 +23,16 @@ EDGETPU_SHARED_LIB = {
 }[platform.system()]
 
 
+def preprocess_image(img):
+    img_resize = cv2.resize(img, (320, 240))
+    img_resize = cv2.cvtColor(img_resize, cv2.COLOR_BGR2RGB)
+    img_resize = img_resize - 127.0
+    img_resize = img_resize / 128.0
+    img_resize = np.float32(np.expand_dims(img_resize, axis=0))
+
+    return img_resize
+
+
 def main():
     converter = tf.lite.TFLiteConverter.from_saved_model(args.save_dir)
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
@@ -52,13 +62,7 @@ def test():
     output_details = interpreter.get_output_details()
 
     img = cv2.imread('imgs/test_input.jpg')
-    h, w, _ = img.shape
-    img_resize = cv2.resize(img, (320, 240))
-    img_resize = cv2.cvtColor(img_resize, cv2.COLOR_BGR2RGB)
-    img_resize = img_resize - 127.0
-    img_resize = img_resize / 128.0
-
-    img_resize = np.float32(np.expand_dims(img_resize, axis=0))
+    img_resize = preprocess_image(img)
 
     interpreter.set_tensor(input_details[0]['index'], img_resize)
 


### PR DESCRIPTION
- Use argparser to handle input arguments for `export_to_tflite.py`
- Add ability to quantize to int8 by specifying calibration data, ie `python3 export_to_tflite.py --repr_data /path/to/calibration/data --quantize_int8`